### PR TITLE
Documentation fixes

### DIFF
--- a/Net_SNMP_util.pm
+++ b/Net_SNMP_util.pm
@@ -1171,7 +1171,7 @@ sub snmpwalkhash($$@) {
 }
 
 
-=head2 snmpmapOID() - add texual OBJECT INDENTIFIER mapping
+=head2 snmpmapOID() - add textual OBJECT INDENTIFIER mapping
 
     snmpmapOID(
 	$text1, $oid1,
@@ -2104,7 +2104,7 @@ earlier than v5.6.0.
 =item *
 
 The Net_SNMP_util module uses the F<Net::SNMP> module, and as such may depend
-on other modules.  Please see the documentaion on F<Net::SNMP> for more
+on other modules.  Please see the documentation on F<Net::SNMP> for more
 information.
 
 =back

--- a/lib/BER.pm
+++ b/lib/BER.pm
@@ -19,7 +19,7 @@ package BER;
 
 =head1 NAME
 
-BER
+BER - Basic Encoding Rules (BER) of Abstract Syntax Notation One (ASN.1)
 
 =head1 SYNOPSIS
 

--- a/lib/SNMP_Session.pm
+++ b/lib/SNMP_Session.pm
@@ -91,7 +91,7 @@ C<map_table_4()>.
 
 my $default_max_repetitions = 12;
 
-=head2 $default avoid_negative_request_ids - default value for
+=head2 $default_avoid_negative_request_ids - default value for
     C<avoid_negative_request_ids>.
 
 Set this to non-zero if you have agents that have trouble with

--- a/security.html
+++ b/security.html
@@ -18,7 +18,7 @@ the University of Oulu in Finland had written an SNMPv1 test suite
 that uncovered difficulties in numerous SNMP implementations with
 respect to improperly encoded SNMP PDUs (Protocol Data Units).
 Possible effects of these vulnerabilities included program crashes as
-well as remote exploitabilities. </p>
+well as remote exploitabilities.</p>
 
 <h2> Why <tt>SNMP_Session.pm</tt>/<tt>BER.pm</tt> Users Shouldn't Be
 Too Concerned </h2>


### PR DESCRIPTION
- Net_SNMP_util.pm: Fix typos in "textual" and "documentation"
- BER.pm: Add short description to NAME field
- SNMP_Session.pm: remove UTF-8 char looking like a whitespace
- security.html: remove 0xA0 (another thing like a whitespace)
 