### PR TITLE
Fix usage of CORE::close()

### DIFF
--- a/lib/SNMP_Session.pm
+++ b/lib/SNMP_Session.pm
@@ -1034,7 +1034,7 @@ sub close {
     ## objects.
     if (! exists $the_socket{$this->{sockfamily}}
 	or $this->sock ne $the_socket{$this->{sockfamily}}) {
-	close ($this->sock) || $this->error ("close: $!");
+	CORE::close ($this->sock) || $this->error ("close: $!");
     }
 }
 


### PR DESCRIPTION
If we are using function/method with same name as Perl core function, it's better use CORE:: prefix for it. use warnings warns about this syntax.